### PR TITLE
feat: Add CLI command to copy translations for Docker/Production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ bench get-app https://github.com/ibrahim317/erpnext-arabic-full-translation
 bench install-app arabic_translations
 ```
 
+### Docker / Production Deployment
+
+If you are using Docker or deploying in a production environment where frontend assets are pre-compiled:
+
+Standard installation hooks only run when installing the app on a site (runtime). However, frontend assets (JS/CSS) are compiled during the image build process. To ensure translations are applied to these assets, you must copy the translation files *before* building the assets.
+
+Add the following step to your custom Dockerfile after installing apps but before running `bench build`:
+
+```dockerfile
+# Install the app
+RUN bench get-app https://github.com/ibrahim317/erpnext-arabic-full-translation
+
+# Copy translation files for all apps in the environment
+RUN bench install-arabic-translations
+
+# Build assets (will include the updated translations)
+RUN bench build
+```
+
 ### Contributing
 
 This app uses `pre-commit` for code formatting and linting. Please [install pre-commit](https://pre-commit.com/#installation) and enable it for this repository:

--- a/arabic_translations/commands.py
+++ b/arabic_translations/commands.py
@@ -1,0 +1,37 @@
+import click
+import frappe
+
+from arabic_translations.utils import copy_locale_files
+
+
+@click.command("install-arabic-translations")
+@click.option("--site", help="Site name")
+def install_arabic_translations(site=None):
+	"""
+	Copy Arabic locale files to apps.
+	If --site is provided, copies only for installed apps on that site.
+	If no site is provided, copies for all apps available in the environment (useful for Docker builds).
+	"""
+	if site:
+		click.echo(f"Copying Arabic translations for site: {site}")
+		frappe.init(site=site)
+		frappe.connect()
+		try:
+			copy_locale_files()
+		finally:
+			frappe.destroy()
+	else:
+		click.echo("No site provided. Copying Arabic translations for all apps in the environment.")
+		# We need to initialize frappe enough to use get_all_apps and get_app_path
+		# frappe.init('') usually works for basic path resolution
+		frappe.init("")
+		try:
+			apps = frappe.get_all_apps(with_internal=True)
+			click.echo(f"Found apps: {', '.join(apps)}")
+			copy_locale_files(apps=apps)
+		except Exception as e:
+			click.echo(f"Error copying translations: {e}")
+			raise e
+
+
+commands = [install_arabic_translations]

--- a/arabic_translations/hooks.py
+++ b/arabic_translations/hooks.py
@@ -242,4 +242,3 @@ after_migrate = "arabic_translations.utils.after_migrate"
 # default_log_clearing_doctypes = {
 # 	"Logging DocType Name": 30  # days to retain logs
 # }
-

--- a/arabic_translations/utils.py
+++ b/arabic_translations/utils.py
@@ -1,108 +1,113 @@
 import os
 import shutil
-from typing import Optional
 
-import frappe 
+import frappe
 
 _LOGGER = frappe.logger("arabic_translations")
 
 
-def before_install(app_name: Optional[str] = None, *args, **kwargs) -> None:
-    """Hook: copy Arabic locale files into installed apps during install."""
-    try:
-        copy_locale_files()
-    except Exception:
-        # Log and swallow to avoid breaking installs; details go to the log file.
-        _LOGGER.exception("Failed to copy Arabic locale files during install")
+def before_install(app_name: str | None = None, *args, **kwargs) -> None:
+	"""Hook: copy Arabic locale files into installed apps during install."""
+	try:
+		copy_locale_files()
+	except Exception:
+		# Log and swallow to avoid breaking installs; details go to the log file.
+		_LOGGER.exception("Failed to copy Arabic locale files during install")
 
 
-def after_app_install(app_name: Optional[str] = None, *args, **kwargs) -> None:
-    """Hook: re-apply Arabic locale files when other apps are installed/updated."""
-    try:
-        # Re-apply translations for all installed apps to ensure Arabic translations
-        # are restored after app updates/reinstalls
-        copy_locale_files()
-        _LOGGER.info("Re-applied Arabic translations after app install/update: %s", app_name or "all apps")
-    except Exception:
-        # Log and swallow to avoid breaking installs; details go to the log file.
-        _LOGGER.exception("Failed to re-apply Arabic locale files after app install/update")
+def after_app_install(app_name: str | None = None, *args, **kwargs) -> None:
+	"""Hook: re-apply Arabic locale files when other apps are installed/updated."""
+	try:
+		# Re-apply translations for all installed apps to ensure Arabic translations
+		# are restored after app updates/reinstalls
+		copy_locale_files()
+		_LOGGER.info("Re-applied Arabic translations after app install/update: %s", app_name or "all apps")
+	except Exception:
+		# Log and swallow to avoid breaking installs; details go to the log file.
+		_LOGGER.exception("Failed to re-apply Arabic locale files after app install/update")
 
 
 def after_migrate() -> None:
-    """Hook: re-apply Arabic locale files after site migration (e.g. bench update)."""
-    try:
-        copy_locale_files()
-        _LOGGER.info("Re-applied Arabic translations after migrate")
-    except Exception:
-        _LOGGER.exception("Failed to re-apply Arabic locale files after migrate")
+	"""Hook: re-apply Arabic locale files after site migration (e.g. bench update)."""
+	try:
+		copy_locale_files()
+		_LOGGER.info("Re-applied Arabic translations after migrate")
+	except Exception:
+		_LOGGER.exception("Failed to re-apply Arabic locale files after migrate")
 
 
+def copy_locale_files(apps: list[str] | None = None) -> None:
+	"""Detect Frappe version/apps and copy ar.po/ar.csv bundles into place.
 
-def copy_locale_files() -> None:
-    """Detect Frappe version/apps and copy ar.po/ar.csv bundles into place."""
-    major = _get_frappe_major_version()
-    if major not in (15, 16):
-        _LOGGER.warning(
-            "Unsupported Frappe version %s; skipping Arabic locale copy", major
-        )
-        return
+	If `apps` is provided, copy for those apps only.
+	Otherwise, detect installed apps on the current site.
+	"""
+	major = _get_frappe_major_version()
+	if major not in (15, 16):
+		_LOGGER.warning("Unsupported Frappe version %s; skipping Arabic locale copy", major)
+		return
 
-    source_root = os.path.join(
-        os.path.dirname(__file__), "locale", "other-apps", f"v{major}"
-    )
-    if not os.path.isdir(source_root):
-        _LOGGER.warning("Locale source path missing: %s", source_root)
-        return
+	source_root = os.path.join(os.path.dirname(__file__), "locale", "other-apps", f"v{major}")
+	if not os.path.isdir(source_root):
+		_LOGGER.warning("Locale source path missing: %s", source_root)
+		return
 
-    installed_apps = frappe.get_installed_apps() or []
-    for app in installed_apps:
-        _copy_for_app(app, source_root)
+	if apps is None:
+		try:
+			apps = frappe.get_installed_apps()
+		except Exception:
+			# Fallback if no site context
+			_LOGGER.warning("Could not get installed apps (no site context?); defaulting to empty list.")
+			apps = []
+
+	apps = apps or []
+	for app in apps:
+		_copy_for_app(app, source_root)
 
 
-def _get_frappe_major_version() -> Optional[int]:
-    raw_version = getattr(frappe, "__version__", "") or ""
-    for sep in ("-", "+"):
-        if sep in raw_version:
-            raw_version = raw_version.split(sep, 1)[0]
-            break
+def _get_frappe_major_version() -> int | None:
+	raw_version = getattr(frappe, "__version__", "") or ""
+	for sep in ("-", "+"):
+		if sep in raw_version:
+			raw_version = raw_version.split(sep, 1)[0]
+			break
 
-    parts = raw_version.split(".")
-    try:
-        return int(parts[0])
-    except Exception:
-        return None
+	parts = raw_version.split(".")
+	try:
+		return int(parts[0])
+	except Exception:
+		return None
 
 
 def _copy_for_app(app: str, source_root: str) -> None:
-    app_source_dir = os.path.join(source_root, app)
-    if not os.path.isdir(app_source_dir):
-        _LOGGER.info("No Arabic locale bundle for app %s at %s", app, app_source_dir)
-        return
+	app_source_dir = os.path.join(source_root, app)
+	if not os.path.isdir(app_source_dir):
+		_LOGGER.info("No Arabic locale bundle for app %s at %s", app, app_source_dir)
+		return
 
-    try:
-        app_dest_root = frappe.get_app_path(app)
-    except Exception:
-        _LOGGER.warning("Could not resolve app path for %s; skipping", app)
-        return
+	try:
+		app_dest_root = frappe.get_app_path(app)
+	except Exception:
+		_LOGGER.warning("Could not resolve app path for %s; skipping", app)
+		return
 
-    for dirpath, _, files in os.walk(app_source_dir):
-        for filename in files:
-            if filename not in {"ar.po", "ar.csv"}:
-                continue
+	for dirpath, _, files in os.walk(app_source_dir):
+		for filename in files:
+			if filename not in {"ar.po", "ar.csv"}:
+				continue
 
-            source_file = os.path.join(dirpath, filename)
-            rel_path = os.path.relpath(source_file, app_source_dir)
+			source_file = os.path.join(dirpath, filename)
+			rel_path = os.path.relpath(source_file, app_source_dir)
 
-            # Drop leading "<app>/" folder from the source bundle so we copy into
-            # the actual app root rather than nesting (source layout includes the
-            # app name).
-            prefix = f"{app}{os.sep}"
-            if rel_path.startswith(prefix):
-                rel_path = rel_path[len(prefix) :]
+			# Drop leading "<app>/" folder from the source bundle so we copy into
+			# the actual app root rather than nesting (source layout includes the
+			# app name).
+			prefix = f"{app}{os.sep}"
+			if rel_path.startswith(prefix):
+				rel_path = rel_path[len(prefix) :]
 
-            dest_path = os.path.join(app_dest_root, rel_path)
+			dest_path = os.path.join(app_dest_root, rel_path)
 
-            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-            shutil.copy2(source_file, dest_path)
-            _LOGGER.info("Copied %s for app %s to %s", filename, app, dest_path)
-
+			os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+			shutil.copy2(source_file, dest_path)
+			_LOGGER.info("Copied %s for app %s to %s", filename, app, dest_path)


### PR DESCRIPTION
This change addresses issue #6 by providing a mechanism to copy translation files during the Docker image build process, ensuring that pre-compiled frontend assets include the updated translations.

- Added `arabic_translations/commands.py` with `install-arabic-translations` command.
- Updated `arabic_translations/utils.py` to support copying translations for a list of apps without a site context.
- Updated `README.md` with Docker deployment instructions.

---
*PR created automatically by Jules for task [5203864800421659430](https://jules.google.com/task/5203864800421659430) started by @ibrahim317*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI pathway that copies/overwrites translation files across all apps (including in Docker build contexts), so misconfiguration could affect packaged assets or app locale files, but logic is small and guarded by version checks.
> 
> **Overview**
> Enables Docker/production image builds to include updated Arabic translations by adding a new `bench install-arabic-translations` CLI command that can run **with or without a site context**.
> 
> Updates `copy_locale_files` to accept an explicit app list (falling back to installed apps when a site is available) and adds a no-site fallback path for build environments; README now documents the required Dockerfile step to run the command before `bench build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08ca00e87928e70714009bf489932a2e7f1734bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->